### PR TITLE
Change GetMinStarValue

### DIFF
--- a/shared/BeatStarSong.hpp
+++ b/shared/BeatStarSong.hpp
@@ -150,7 +150,7 @@ namespace SDC_wrapper {
                 double min = -1.0f;
                 for (auto diff : diffVec) 
                 {
-                    if (min < 0 || diff->stars < min) min = diff->stars;
+                    if (diff->stars > 0 && (min < 0 || diff->stars < min)) min = diff->stars;
                 }
                 return min;
             }


### PR DESCRIPTION
The way it was originally had it so it could return 0 if a difficulty was unranked. It now checks if the difficulty is greater than 0 to make sure this doesn't happen.